### PR TITLE
Allow the resource to read different mounts

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -10,5 +10,5 @@ login() {
 }
 
 get_secret() {
-    vault read -format=json secret/${1} | jq -r '.data'
+    vault read -format=json ${1} | jq -r '.data'
 }


### PR DESCRIPTION
It is possible to create different generic mounts (we use them to separate different customers for example)
This patch doesn't force the use of the secret mount anymore and let the user choose the mount he want to read