### PR TITLE
approle: Add AppRole authentication method

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 # Vault Resource
 
-Reads secrets from [Vault](https://www.vaultproject.io/). Authentication is done using the [aws-ec2 method](https://www.vaultproject.io/docs/auth/aws-ec2.html), which must be configured before using this resource.
+Reads secrets from [Vault](https://www.vaultproject.io/). Authentication is done (by default) using the [aws-ec2 method](https://www.vaultproject.io/docs/auth/aws-ec2.html), which must be configured before using this resource.
+It can also use the [AppRole method](https://www.vaultproject.io/docs/auth/approle.html) to authenticate.
 
 ## Source Configuration
 
@@ -14,13 +15,19 @@ Reads secrets from [Vault](https://www.vaultproject.io/). Authentication is done
 
 * `paths`: *Optional.* If specified (as a list of glob patterns), only changes
   to the specified files will yield new versions from `check`.
+  
+* `auth_method`: *Optional.* By default will use the `aws-ec2` method. If `AppRole` is specified, it will read the `role_id` and `secret_id` parameter to authenticate on the approle endpoint. 
+
+* `role_id`: *Optional.* Use a specific role id to authenticate. This parameter is used only with `auth_method: AppRole`. 
+
+* `secret_id`: *Optional.* Use a specific secret id to authenticate. This parameter is used only with `auth_method: AppRole`. 
 
 * `tls_skip_verify`: *Optional.* Skips Vault SSL verification by exporting
   `VAUKT_SKIP_VERIFY=1`.
 
 ### Example
 
-Resource configuration:
+Resource configuration using aws-ec2 authentication:
 
 ``` yaml
 resources:
@@ -30,6 +37,19 @@ resources:
     url: https://secure.legitcompany.com:8200
     role: build-server
     nonce: cantguessme
+```
+
+Resource configuration using AppRole authentication:
+
+``` yaml
+resources:
+- name: vault
+  type: vault
+  source:
+    url: https://secure.legitcompany.com:8200
+    auth_method: AppRole
+    role_id: e6889709-5ff8-c670-a083-79f1c5035709
+    secret_id: e6889709-5ff8-c670-a083-79f1c5035709
 ```
 
 Fetching secrets:

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -1,8 +1,18 @@
-login() {
+login_aws_ec2() {
     vault_role="$1"
     vault_nonce="$2"
     cert=$(curl -s http://169.254.169.254/latest/dynamic/instance-identity/pkcs7 | tr -d '\n')
     token=$(vault write -format=json auth/aws-ec2/login role=${vault_role} pkcs7=${cert} nonce=${vault_nonce} | jq -r '.auth.client_token')
+    if [ -z "${token}" ]; then
+        echo "ERROR: No token retrieved"
+    fi
+    echo -n "${token}" > ~/.vault-token
+}
+
+login_approle() {
+    vault_role_id="$1"
+    vault_secret_id="$2"
+    token=$(vault write -format=json auth/approle/login role_id=${vault_role_id} secret_id=${vault_secret_id} | jq -r '.auth.client_token')
     if [ -z "${token}" ]; then
         echo "ERROR: No token retrieved"
     fi

--- a/assets/in
+++ b/assets/in
@@ -13,9 +13,14 @@ cat > $payload <&0
 
 url=$(jq -r '.source.url // "https://vault.service.consul:8200"' < $payload)
 skip_verify=$(jq -r '.source.tls_skip_verify // ""' < $payload)
+paths=($(jq -r '.params.paths // [] | .[]' < $payload))
+auth_method=$(jq -r '.source.auth_method // "aws_ec2"' < $payload)
+# Used for AWS EC2 authentication
 role=$(jq -r '.source.role // "concourse"' < $payload)
 nonce=$(jq -r '.source.nonce // "vault-concourse-nonce"' < $payload)
-paths=($(jq -r '.params.paths // [] | .[]' < $payload))
+# Used for AWS EC2 authentication
+role_id=$(jq -r '.source.role_id // ""' < $payload)
+secret_id=$(jq -r '.source.secret_id // ""' < $payload)
 
 echo "INFO: Reading secrets from: ${paths[*]}"
 
@@ -25,7 +30,11 @@ if [ ! -z "${skip_verify}" ]; then
     export VAULT_SKIP_VERIFY=1
 fi
 
-login ${role} ${nonce}
+if [ "${auth_method}" = "AppRole" ]; then
+    login_approle ${role_id} ${secret_id}
+else
+    login_aws_ec2 ${role} ${nonce}
+fi
 
 for path in "${paths[@]}"; do
     mkdir -p ${destination}/$(dirname ${path})


### PR DESCRIPTION
This commit add the ability to authenticate on the approle endpoint.
On a shared concourse ci, you may not want to use a common certificate which will give the same rights to every pipelines/teams.

Using a specific policy for a role allow to have more granular ACL across your pipelines.

To not break default behavior and existing pipelines, I kept the aws-ec2 authentication as default.

Fix #5 