### PR TITLE
common.sh: fix return code when errors happen

### DIFF
--- a/assets/common.sh
+++ b/assets/common.sh
@@ -5,6 +5,7 @@ login_aws_ec2() {
     token=$(vault write -format=json auth/aws-ec2/login role=${vault_role} pkcs7=${cert} nonce=${vault_nonce} | jq -r '.auth.client_token')
     if [ -z "${token}" ]; then
         echo "ERROR: No token retrieved"
+	return 1
     fi
     echo -n "${token}" > ~/.vault-token
 }
@@ -15,6 +16,7 @@ login_approle() {
     token=$(vault write -format=json auth/approle/login role_id=${vault_role_id} secret_id=${vault_secret_id} | jq -r '.auth.client_token')
     if [ -z "${token}" ]; then
         echo "ERROR: No token retrieved"
+	return 1
     fi
     echo -n "${token}" > ~/.vault-token
 }


### PR DESCRIPTION
Errors can be hidden by the use of pipeline in a command line. The
method needs then to return something else than 0 if we want the program
to exit, otherwise the 'set -e' is not enough.

Tested locally with a similar use-case:
```
$ ./test.sh && echo "=> Success" || echo "=> Fail"
Source: Something wrong happened
Source: end
Test: end
=> Success

$ cp source.sh source.sh.orig
'source.sh' -> 'source.sh.orig'

$ ./test.sh && echo "=> Success" || echo "=> Fail"
Source: Something wrong happened
=> Fail

$ diff -c source.sh.orig source.sh
*** source.sh.orig	2017-01-27 16:07:25.413655275 +0100
--- source.sh	2017-01-27 16:07:30.473800733 +0100
***************
*** 3,7 ****
--- 3,8 ----
  VAR=$(curl -s https://test.test/ -m 1 | tr -d '\n')
  if [ -z "$VAR" ]; then
  	echo "Source: Something wrong happened"
+ 	return 1
  fi
  echo "Source: end"
```
Files used are similar to https://github.com/Docurated/concourse-vault-resource/issues/7.

Fixes https://github.com/Docurated/concourse-vault-resource/issues/7