### PR TITLE
token: Expose optionally the vault token to use it on other resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ It can also use the [AppRole method](https://www.vaultproject.io/docs/auth/appro
 * `paths`: *Optional.* If specified (as a list of glob patterns), only changes
   to the specified files will yield new versions from `check`.
   
+* `expose_token`: *Optional.* If specified, this option will expose the token to make it available to other resources
+  
 * `auth_method`: *Optional.* By default will use the `aws-ec2` method. If `AppRole` is specified, it will read the `role_id` and `secret_id` parameter to authenticate on the approle endpoint. 
 
 * `role_id`: *Optional.* Use a specific role id to authenticate. This parameter is used only with `auth_method: AppRole`. 

--- a/assets/in
+++ b/assets/in
@@ -13,6 +13,7 @@ cat > $payload <&0
 
 url=$(jq -r '.source.url // "https://vault.service.consul:8200"' < $payload)
 skip_verify=$(jq -r '.source.tls_skip_verify // ""' < $payload)
+expose_token=$(jq -r '.source.expose_token // ""' < $payload)
 paths=($(jq -r '.params.paths // [] | .[]' < $payload))
 auth_method=$(jq -r '.source.auth_method // "aws_ec2"' < $payload)
 # Used for AWS EC2 authentication
@@ -40,6 +41,10 @@ for path in "${paths[@]}"; do
     mkdir -p ${destination}/$(dirname ${path})
     get_secret ${path} > ${destination}/${path}.json
 done
+
+if [ ! -z "${expose_token}" ]; then
+    cp ~/.vault-token ${destination}/token
+fi
 
 version="{\"date\": \"$(date +%s)\"}"
 jq -n "{


### PR DESCRIPTION
I needed to get the token to inject it in a terraform variable to configure the vault provider.
Terraform will create a new token (with a ttl) using the token given in parameters.
Unfortunately, I wasn't able to get the token of the vault resource. This patch add a variable to explicitely expose the token in the same path than secret, to be able to read it on other resources