### PR TITLE
Add a new source parameter "ca_cert"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ It can also use the [AppRole method](https://www.vaultproject.io/docs/auth/appro
 
 * `secret_id`: *Optional.* Use a specific secret id to authenticate. This parameter is used only with `auth_method: AppRole`. 
 
+* `ca_cert`: *Optional.* Use a x509 CA certificate to use to verify the Vault server SSL certificate.
+    ```yaml
+    ca_cert: |
+        -----BEGIN CERTIFICATE-----
+        ...
+        -----END CERTIFICATE-----
+    ```
+
 * `tls_skip_verify`: *Optional.* Skips Vault SSL verification by exporting
   `VAUKT_SKIP_VERIFY=1`.
 

--- a/assets/in
+++ b/assets/in
@@ -12,6 +12,7 @@ payload=$(mktemp $TMPDIR/vault-resource-request.XXXXXX)
 cat > $payload <&0
 
 url=$(jq -r '.source.url // "https://vault.service.consul:8200"' < $payload)
+ca_cert=$(jq -r '.source.ca_cert // ""' < $payload)
 skip_verify=$(jq -r '.source.tls_skip_verify // ""' < $payload)
 expose_token=$(jq -r '.source.expose_token // ""' < $payload)
 paths=($(jq -r '.params.paths // [] | .[]' < $payload))
@@ -26,6 +27,12 @@ secret_id=$(jq -r '.source.secret_id // ""' < $payload)
 echo "INFO: Reading secrets from: ${paths[*]}"
 
 export VAULT_ADDR=${url}
+
+if [ -n "${ca_cert}" ]; then
+    export VAULT_CACERT=$(mktemp $TMPDIR/vault-resource-cacert.XXXXXX)
+    echo "${ca_cert}" > ${VAULT_CACERT}
+fi
+
 if [ ! -z "${skip_verify}" ]; then
     echo "WARN: Disabling TLS verification for Vault"
     export VAULT_SKIP_VERIFY=1


### PR DESCRIPTION
This source parameter allows us to use a x509 CA certificate to use to verify the Vault server SSL certificate.

* `ca_cert`: *Optional.* Use a x509 CA certificate to use to verify the Vault server SSL certificate.
    ```yaml
    ca_cert: |
        -----BEGIN CERTIFICATE-----
        ...
        -----END CERTIFICATE-----
    ```