### PR TITLE
support kv2 secrets backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest
 MAINTAINER William Huba <william.huba@docurated.com>
 
-ENV VAULT_VERSION 0.6.1
+ENV VAULT_VERSION 0.10.4
 
 RUN apk update && apk add --no-cache \
     openssl \

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -22,5 +22,5 @@ login_approle() {
 }
 
 get_secret() {
-    vault read -format=json ${1} | jq -r '.data'
+    vault kv get -format=json ${1} | jq -r '.data'
 }


### PR DESCRIPTION
I confirmed this is backwards compatible, kv1 backends will still return results the way they always have.